### PR TITLE
docs: Add Cloudflare Pages deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # uplabdhi_G
+
+## Deployment to Cloudflare Pages
+
+1.  **Push to GitHub/GitLab:** Ensure your project is pushed to a GitHub or GitLab repository.
+2.  **Connect to Cloudflare Pages:**
+    *   Log in to the Cloudflare dashboard.
+    *   Navigate to Workers & Pages > Create application > Pages > Connect to Git.
+    *   Select your repository.
+3.  **Configure Build Settings:**
+    *   **Production branch:** Select your main branch (e.g., `main` or `master`).
+    *   **Build command:** `npm run build`
+    *   **Build output directory:** `dist`
+    *   **Environment variables (optional):** If you encounter Node.js version issues during the build on Cloudflare, you might need to set `NODE_VERSION` here. Check Cloudflare's build image defaults or set a version compatible with the `engines` field in your `package.json` (e.g., `>=18.20.0`).
+4.  **Deploy:** Save and Deploy. Cloudflare Pages will automatically build and deploy your site. It will also redeploy on subsequent pushes to your production branch.

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"
+  },
+  "engines": {
+    "node": ">=18.20.0"
   }
 }


### PR DESCRIPTION
- Updated README.md with a new section on deploying to Cloudflare Pages.
- Instructions include connecting to Git, build configuration (npm run build, dist directory), and a note on NODE_VERSION environment variable.
- Also updated package.json to include an 'engines' field specifying Node.js >=18.20.0 to address potential babel-loader compatibility warnings.